### PR TITLE
Remove replacement of non existing migration

### DIFF
--- a/social_django/migrations/0005_auto_20160727_2333.py
+++ b/social_django/migrations/0005_auto_20160727_2333.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     replaces = [
-        ('default', '0005_auto_20160727_2333'),
         ('social_auth', '0005_auto_20160727_2333')
     ]
 


### PR DESCRIPTION
Fixes #16, #9, #13 

This migration did never exist for `default` app as old python-social-auth didn't ship it and the new one did not replace. Replacing it now leads to Django seeing it as partially applied...