### PR TITLE
Pass request in kwargs if we have received it

### DIFF
--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -117,6 +117,8 @@ class DjangoStrategy(BaseStrategy):
     def clean_authenticate_args(self, request=None, *args, **kwargs):
         """Cleanup request argument if present, which is passed to
         authenticate as for Django 1.11"""
+        if request is not None:
+            kwargs['request'] = request
         return args, kwargs
 
     def session_get(self, name, default=None):


### PR DESCRIPTION
In Django 1.10 and olders, request is part of kwargs, by throwing it
away in Django 1.11 we make it unavailable to the pipeline.

This is followup for #24