### PR TITLE
Write a few tests for models

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from social_django.models import UserSocialAuth
+
+
+class TestSocialAuthUser(TestCase):
+
+    def test_user_relationship_none(self):
+        """Accessing User.social_user outside of the pipeline doesn't work"""
+        User = get_user_model()
+        user = User.objects.create_user(username="randomtester")
+        with self.assertRaises(AttributeError):
+            user.social_user
+
+    def test_user_existing_relationship(self):
+        """Accessing User.social_user outside of the pipeline doesn't work"""
+        User = get_user_model()
+        user = User.objects.create_user(username="randomtester")
+        UserSocialAuth.objects.create(user=user, provider='my-provider', uid='1234')
+        with self.assertRaises(AttributeError):
+            user.social_user
+
+    def test_get_social_auth(self):
+        User = get_user_model()
+        user = User.objects.create_user(username="randomtester")
+        user_social = UserSocialAuth.objects.create(user=user, provider='my-provider', uid='1234')
+        other = UserSocialAuth.get_social_auth('my-provider', '1234')
+        self.assertEqual(other, user_social)
+
+    def test_get_social_auth_none(self):
+        other = UserSocialAuth.get_social_auth('my-provider', '1234')
+        self.assertIsNone(other)


### PR DESCRIPTION
Wrote these tests while investigating a problem I had while writing a custom backend.

While implementing a custom Backend, I had an error in the `do_complete()` function where the `social_user` was `None`, shortly after social_core did `social_user = user.social_user`.

After a bit of research, it was because my backend needed to override `ID_KEY`. The error wasn't clearly raised and [the docs](http://python-socialauth.readthedocs.io/en/latest/backends/implementation.html#shared-attributes) do not mention this caveat.

From what I gathered, something is setting the `social_user` attribute on the request's user. These tests are showing that the attribute isn't normally set.

Would you accept a PR in the core or in the docs to try to make this caveat more obvious? That would have saved me a bit of time.