### PR TITLE
Tests: install django 1.10, not 1.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = coverage run manage.py test
 deps =
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
-    django-110: Django>=1.10
+    django-110: Django>=1.10,<1.11
     -r{toxinidir}/requirements.txt
     codecov
 basepython =


### PR DESCRIPTION
Django 1.11 [is progressing](https://www.djangoproject.com/weblog/2017/jan/17/django-111-alpha-1/), with the current setup the tests for Django 1.10 are going to run against 1.11 when released.