### PR TITLE
Association ID is integer

### DIFF
--- a/social_django/urls.py
+++ b/social_django/urls.py
@@ -19,6 +19,6 @@ urlpatterns = [
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,
         name='disconnect'),
-    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>[^/]+){0}$'
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+){0}$'
         .format(extra), views.disconnect, name='disconnect_individual'),
 ]


### PR DESCRIPTION
Accept only integers in the URL as association ID, otherwise it fails
later.

Otherwise you end up with ValueError later:

```
File "social_core/pipeline/disconnect.py" in allowed_to_disconnect
  6.     if not user_storage.allowed_to_disconnect(user, name, association_id):

File "social_django/storage.py" in allowed_to_disconnect
  25.             qs = cls.objects.exclude(id=association_id)

File "/usr/lib/python2.7/dist-packages/django/db/models/manager.py" in manager_method
  85.                 return getattr(self.get_queryset(), name)(*args, **kwargs)

File "/usr/lib/python2.7/dist-packages/django/db/models/query.py" in exclude
  803.         return self._filter_or_exclude(True, *args, **kwargs)

File "/usr/lib/python2.7/dist-packages/django/db/models/query.py" in _filter_or_exclude
  812.             clone.query.add_q(~Q(*args, **kwargs))

File "/usr/lib/python2.7/dist-packages/django/db/models/sql/query.py" in add_q
  1227.         clause, _ = self._add_q(q_object, self.used_aliases)

File "/usr/lib/python2.7/dist-packages/django/db/models/sql/query.py" in _add_q
  1253.                     allow_joins=allow_joins, split_subq=split_subq,

File "/usr/lib/python2.7/dist-packages/django/db/models/sql/query.py" in build_filter
  1187.             condition = self.build_lookup(lookups, col, value)

File "/usr/lib/python2.7/dist-packages/django/db/models/sql/query.py" in build_lookup
  1083.                 return final_lookup(lhs, rhs)

File "/usr/lib/python2.7/dist-packages/django/db/models/lookups.py" in __init__
  19.         self.rhs = self.get_prep_lookup()

File "/usr/lib/python2.7/dist-packages/django/db/models/lookups.py" in get_prep_lookup
  59.             return self.lhs.output_field.get_prep_value(self.rhs)

File "/usr/lib/python2.7/dist-packages/django/db/models/fields/__init__.py" in get_prep_value
  946.         return int(value)

Exception Type: ValueError at /accounts/disconnect/email/";alert(299792458);"/
Exception Value: invalid literal for int() with base 10: '";alert(299792458);"'
```