### PR TITLE
Allow configurable maximum session length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   fast_finish: true
 
-install: pip install -r requirements.txt tox codecov
+install: pip install -r dev-requirements.txt
 
 script: tox -e $TOX_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-app-django/commits/master)
 
+### Added
+- Check for a `MAX_SESSION_LENGTH` setting when logging in and setting session expiry.
+
 ## [1.1.0](https://github.com/python-social-auth/social-app-django/releases/tag/1.1.0) - 2017-02-10
 
 ### Added

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+mock==2.0.0
+codecov==2.0.7
+tox==2.7.0
+-r requirements.txt

--- a/social_django/views.py
+++ b/social_django/views.py
@@ -12,6 +12,10 @@ from .utils import psa
 
 NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
 
+# Calling `session.set_expiry(None)` results in a session lifetime equal to
+# platform default session lifetime.
+DEFAULT_SESSION_TIMEOUT = None
+
 
 @never_cache
 @psa('{0}:complete'.format(NAMESPACE))
@@ -39,21 +43,86 @@ def disconnect(request, backend, association_id=None):
                          redirect_name=REDIRECT_FIELD_NAME)
 
 
+def get_session_timeout(social_user, enable_session_expiration=False,
+                        max_session_length=None):
+    if enable_session_expiration:
+        # Retrieve an expiration date from the social user who just finished
+        # logging in; this value was set by the social auth backend, and was
+        # typically received from the server.
+        expiration = social_user.expiration_datetime()
+
+        # We've enabled session expiration. Check to see if we got
+        # a specific expiration time from the provider for this user;
+        # if not, use the platform default expiration.
+        if expiration:
+            received_expiration_time = expiration.total_seconds()
+        else:
+            received_expiration_time = DEFAULT_SESSION_TIMEOUT
+
+        # Check to see if the backend set a value as a maximum length
+        # that a session may be; if they did, then we should use the minimum
+        # of that and the received session expiration time, if any, to
+        # set the session length.
+        if received_expiration_time is None and max_session_length is None:
+            # We neither received an expiration length, nor have a maximum
+            # session length. Use the platform default.
+            session_expiry = DEFAULT_SESSION_TIMEOUT
+        elif received_expiration_time is None and max_session_length is not None:
+            # We only have a maximum session length; use that.
+            session_expiry = max_session_length
+        elif received_expiration_time is not None and max_session_length is None:
+            # We only have an expiration time received by the backend
+            # from the provider, with no set maximum. Use that.
+            session_expiry = received_expiration_time
+        else:
+            # We received an expiration time from the backend, and we also
+            # have a set maximum session length. Use the smaller of the two.
+            session_expiry = min(received_expiration_time, max_session_length)
+    else:
+        # If there's an explicitly-set maximum session length, use that
+        # even if we don't want to retrieve session expiry times from
+        # the backend. If there isn't, then use the platform default.
+        if max_session_length is None:
+            session_expiry = DEFAULT_SESSION_TIMEOUT
+        else:
+            session_expiry = max_session_length
+
+    return session_expiry
+
+
 def _do_login(backend, user, social_user):
     user.backend = '{0}.{1}'.format(backend.__module__,
                                   backend.__class__.__name__)
+    # Get these details early to avoid any issues involved in the
+    # session switch that happens when we call login().
+    enable_session_expiration = backend.setting('SESSION_EXPIRATION', False)
+    max_session_length_setting = backend.setting('MAX_SESSION_LENGTH', None)
+
+    # Log the user in, creating a new session.
     login(backend.strategy.request, user)
-    if backend.setting('SESSION_EXPIRATION', False):
-        # Set session expiration date if present and enabled
-        # by setting. Use last social-auth instance for current
-        # provider, users can associate several accounts with
-        # a same provider.
-        expiration = social_user.expiration_datetime()
-        if expiration:
-            try:
-                backend.strategy.request.session.set_expiry(
-                    expiration.seconds + expiration.days * 86400
-                )
-            except OverflowError:
-                # Handle django time zone overflow
-                backend.strategy.request.session.set_expiry(None)
+
+    # Make sure that the max_session_length value is either an integer or
+    # None. Because we get this as a setting from the backend, it can be set
+    # to whatever the backend creator wants; we want to be resilient against
+    # unexpected types being presented to us.
+    try:
+        max_session_length = int(max_session_length_setting)
+    except (TypeError, ValueError):
+        # We got a response that doesn't look like a number; use the default.
+        max_session_length = None
+
+    # Get the session expiration length based on the maximum session length
+    # setting, combined with any session length received from the backend.
+    session_expiry = get_session_timeout(
+        social_user,
+        enable_session_expiration=enable_session_expiration,
+        max_session_length=max_session_length,
+    )
+
+    try:
+        # Set the session length to our previously determined expiry length.
+        backend.strategy.request.session.set_expiry(session_expiry)
+    except OverflowError:
+        # The timestamp we used wasn't in the range of values supported by
+        # Django for session length; use the platform default. We tried.
+        backend.strategy.request.session.set_expiry(DEFAULT_SESSION_TIMEOUT)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+import mock
+
 from django.test import Client
 from django.test import TestCase
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
+
+from social_django.views import get_session_timeout
 
 
 class TestConfig(TestCase):
@@ -18,3 +22,83 @@ class TestConfig(TestCase):
     def test_begin_view(self):
         response = self.client.get(reverse('social:begin', kwargs={'backend': 'facebook'}))
         self.assertEqual(response.status_code, 302)
+
+class TestGetSessionTimeout(TestCase):
+    """
+    Ensure that the branching logic of get_session_timeout behaves as expected.
+    """
+
+    def setUp(self):
+        self.social_user = mock.MagicMock()
+        self.social_user.expiration_datetime.return_value = None
+        super(TestGetSessionTimeout, self).setUp()
+
+    def set_user_expiration(self, seconds):
+        self.social_user.expiration_datetime.return_value = mock.MagicMock(
+            total_seconds = mock.MagicMock(return_value=seconds)
+        )
+
+    def test_expiration_disabled_no_max(self):
+        self.set_user_expiration(60)
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=False
+        )
+        self.assertIsNone(expiration_length)
+
+    def test_expiration_disabled_with_max(self):
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=False,
+            max_session_length=60
+        )
+        self.assertEqual(expiration_length, 60)
+
+    def test_expiration_disabled_with_zero_max(self):
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=False,
+            max_session_length=0
+        )
+        self.assertEqual(expiration_length, 0)
+
+    def test_user_has_session_length_no_max(self):
+        self.set_user_expiration(60)
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=True
+        )
+        self.assertEqual(expiration_length, 60)
+
+    def test_user_has_session_length_larger_max(self):
+        self.set_user_expiration(60)
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=True,
+            max_session_length=90
+        )
+        self.assertEqual(expiration_length, 60)
+
+    def test_user_has_session_length_smaller_max(self):
+        self.set_user_expiration(60)
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=True,
+            max_session_length=30
+        )
+        self.assertEqual(expiration_length, 30)
+
+    def test_user_has_no_session_length_with_max(self):
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=True,
+            max_session_length=60
+        )
+        self.assertEqual(expiration_length, 60)
+
+    def test_user_has_no_session_length_no_max(self):
+        expiration_length = get_session_timeout(
+            self.social_user,
+            enable_session_expiration=True
+        )
+        self.assertIsNone(expiration_length)

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps =
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2
-    -r{toxinidir}/requirements.txt
-    codecov
+    -r{toxinidir}/dev-requirements.txt
+
 basepython =
     py35: python3.5
     py34: python3.4


### PR DESCRIPTION
Implements #53.

This pull request adds a configurable setting `MAX_SESSION_LENGTH` which, when set, allows service providers to set the maximum length of time that a user who logs in via social auth may remain logged in. If set to 0, the session will expire on browser close. If not set, then either the session length received from the social auth provider (if available) or the platform default session length will be used.

This pull request also makes some small tweaks to the testing framework; it consolidates requirements into a single `dev-requirements.txt` file and references that file in `.travis.yml` and in `tox.ini`.

Note: The current version of `social-core` does not wipe `partial_pipeline_token` from the browser session on completion of the pipeline, but in the past, the pipeline was wiped before calling. Our specific use case for this involves using variables available within the pipeline kwargs (specifically, we need to be able to identify the specific SAML provider configuration in use with that backend) , so we'd like to be aware of whether that particular change was intended.