### PR TITLE
Added support to use django.contrib.postgres.fields.JSONField

### DIFF
--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -24,7 +24,7 @@ else:
 
 field_class = functools.partial(six.with_metaclass, field_metaclass)
 
-if getattr(settings, 'SOCIAL_DJANGO_POSTGRES_JSONFIELD'):
+if getattr(settings, 'SOCIAL_DJANGO_POSTGRES_JSONFIELD', False):
     from django.contrib.postgres.fields import JSONField as JSONFieldBase
 else:
     JSONFieldBase = field_class(models.TextField)

--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -5,6 +5,7 @@ import functools
 import django
 
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.db import models
 
 try:
@@ -23,8 +24,13 @@ else:
 
 field_class = functools.partial(six.with_metaclass, field_metaclass)
 
+if getattr(settings, 'SOCIAL_DJANGO_POSTGRES_JSONFIELD'):
+    from django.contrib.postgres.fields import JSONField as JSONFieldBase
+else:
+    JSONFieldBase = field_class(models.TextField)
 
-class JSONField(field_class(models.TextField)):
+
+class JSONField(JSONFieldBase):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """

--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.db import models
 
+from social_core.utils import setting_name
+
 try:
     from django.utils.encoding import smart_unicode as smart_text
     smart_text  # placate pyflakes
@@ -24,7 +26,7 @@ else:
 
 field_class = functools.partial(six.with_metaclass, field_metaclass)
 
-if getattr(settings, 'SOCIAL_DJANGO_POSTGRES_JSONFIELD', False):
+if getattr(settings, setting_name('POSTGRES_JSONFIELD'), False):
     from django.contrib.postgres.fields import JSONField as JSONFieldBase
 else:
     JSONFieldBase = field_class(models.TextField)


### PR DESCRIPTION
Seems like support to use django.contrib.postgres.fields.JSONField as base Field class for extra_data will be useful, because postgres JSONField usage provides ability to make complex queries over extra_data