### PR TITLE
Run tests against Python 3.6 and Django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,18 @@ env:
   - TOX_ENV=py35-django-111
   - TOX_ENV=py34-django-111
   - TOX_ENV=py27-django-111
+  - TOX_ENV=py35-django-master
 
 matrix:
   fast_finish: true
+  include:
+    - python: "3.6"
+      env: TOX_ENV=py36-django-111
+    - python: "3.6"
+      env: TOX_ENV=py36-django-master
+  allow_failures:
+    - env: TOX_ENV=py35-django-master
+    - env: TOX_ENV=py36-django-master
 
 install: pip install -r dev-requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
     {py27,py33,py34,py35}-django-18
     {py27,py34,py35}-django-19
     {py27,py34,py35}-django-110
-    {py27,py34,py35}-django-111
+    {py27,py34,py35,py36}-django-111
+    {py35,py36}-django-master
 
 [testenv]
 setenv =
@@ -14,9 +15,11 @@ deps =
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2
+    django-master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/dev-requirements.txt
 
 basepython =
+    py36: python3.6
     py35: python3.5
     py34: python3.4
     py33: python3.3


### PR DESCRIPTION
In order to prepare for Django 2.0 (https://github.com/python-social-auth/social-app-django/issues/6), update the build matrix to run tests on django master with allowed failures.

While I'm at it, I thought I would update it to run on Python 3.6 as well.