### PR TITLE
Remove “clean_authenticate_args” in DjangoStrategy

### DIFF
--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -114,13 +114,6 @@ class DjangoStrategy(BaseStrategy):
         kwargs['backend'] = backend
         return authenticate(*args, **kwargs)
 
-    def clean_authenticate_args(self, request=None, *args, **kwargs):
-        """Cleanup request argument if present, which is passed to
-        authenticate as for Django 1.11"""
-        if request is not None:
-            kwargs['request'] = request
-        return args, kwargs
-
     def session_get(self, name, default=None):
         return self.session.get(name, default)
 


### PR DESCRIPTION
The clean_authenticate_args() in DjangoStrategy is causing an error of “got multiple values for keyword argument 'request’”