### PR TITLE
Use urlquote instead of built-in quote 

### DIFF
--- a/social_django/context_processors.py
+++ b/social_django/context_processors.py
@@ -1,7 +1,6 @@
-from six.moves.urllib_parse import quote
-
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.utils.functional import SimpleLazyObject
+from django.utils.http import urlquote
 
 try:
     from django.utils.functional import empty as _empty
@@ -41,7 +40,7 @@ def login_redirect(request):
                 request.POST.get(REDIRECT_FIELD_NAME) or \
                 request.GET.get(REDIRECT_FIELD_NAME)
     if value:
-        value = quote(value)
+        value = urlquote(value)
         querystring = REDIRECT_FIELD_NAME + '=' + value
     else:
         querystring = ''

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase, RequestFactory, override_settings
+
+from social_django.context_processors import login_redirect
+
+
+@override_settings(REDIRECT_FIELD_NAME='next')
+class TestContextProcessors(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_login_redirect_unicode_quote(self):
+        request = self.request_factory.get('/', data={'next': 'profile/sjó'})
+        result = login_redirect(request)
+        self.assertEqual(
+            result,  {
+                 'REDIRECT_FIELD_NAME': 'next',
+                 'REDIRECT_FIELD_VALUE': 'profile/sj%C3%B3',
+                 'REDIRECT_QUERYSTRING': 'next=profile/sj%C3%B3'
+            }
+        )


### PR DESCRIPTION
Since it can handle unicode out of the box

https://docs.djangoproject.com/en/1.11/_modules/django/utils/http/#urlquote

Python 3 is not affected but for 2.7 it can cause problems.

Will fix #60