### PR TITLE
Django 2.0 support: don't use the removed _get_val_from_obj()

### DIFF
--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -85,8 +85,10 @@ class JSONField(JSONFieldBase):
 
     def value_to_string(self, obj):
         """Return value from object converted to string properly"""
-        return smart_text(self.get_prep_value(self._get_val_from_obj(obj)))
+        return smart_text(self.value_from_object(obj))
 
     def value_from_object(self, obj):
         """Return value dumped to string."""
-        return self.get_prep_value(self._get_val_from_obj(obj))
+        orig_val = super(JSONField, self).value_from_object(obj)
+        return self.get_prep_value(orig_val)
+


### PR DESCRIPTION
Fix #101 