### PR TITLE
More pythonic way to handle urlresolvers deprecation

### DIFF
--- a/social_django/compat.py
+++ b/social_django/compat.py
@@ -3,9 +3,9 @@ import six
 import django
 from django.db import models
 
-if django.VERSION >= (2, 0):
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
 
 if django.VERSION >= (1, 10):


### PR DESCRIPTION
`django.core.urlresolvers` is deprecated since version 1.10
https://docs.djangoproject.com/en/1.10/ref/urlresolvers/#module-django.urls

With this simple commit `django.urls` will be used if present avoiding very annoying warnings with Django >= 1.10