### PR TITLE
Drop old tables

### DIFF
--- a/social_django/migrations/0001_initial.py
+++ b/social_django/migrations/0001_initial.py
@@ -24,6 +24,25 @@ ASSOCIATION_HANDLE_LENGTH = getattr(
     settings, setting_name('ASSOCIATION_HANDLE_LENGTH'), 255
 )
 
+def delete_existing(apps, schema_editor):
+    from django.db import connection
+
+    table_names = [
+        'social_auth_association',
+        'social_auth_nonce',
+        'social_auth_usersocialauth',
+    ]
+    for x in table_names:
+        # drop the table using sql
+        # no worry about sql injection
+        # since this query is being generated
+        # by us
+        sql = 'drop table if exists %s' % (x,)
+        schema_editor.execute(sql)
+
+
+def backwards(apps, schema_editor):
+    pass
 
 class Migration(migrations.Migration):
     replaces = [
@@ -36,6 +55,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(delete_existing, backwards),
         migrations.CreateModel(
             name='Association',
             fields=[

--- a/social_django/storage.py
+++ b/social_django/storage.py
@@ -96,7 +96,8 @@ class DjangoUserMixin(UserMixin):
     def get_users_by_email(cls, email):
         user_model = cls.user_model()
         email_field = getattr(user_model, 'EMAIL_FIELD', 'email')
-        return user_model.objects.filter(**{email_field + '__iexact': email})
+        active_field = getattr(user_model, 'ACTIVE_FIELD', 'is_active')
+        return user_model.objects.filter(**{email_field + '__iexact': email,active_field: True})
 
     @classmethod
     def get_social_auth(cls, provider, uid):


### PR DESCRIPTION
Old social auth tables existed in db causing migration to failed.  This PR will drop the existing tables and recreate new ones.