### PR TITLE
Pull request for https://github.com/python-social-auth/social-app-django/issues/114

### DIFF
--- a/social_django/migrations/0001_initial.py
+++ b/social_django/migrations/0001_initial.py
@@ -26,10 +26,6 @@ ASSOCIATION_HANDLE_LENGTH = getattr(
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        ('default', '0001_initial'),
-        ('social_auth', '0001_initial')
-    ]
 
     dependencies = [
         migrations.swappable_dependency(USER_MODEL),

--- a/social_django/migrations/0002_add_related_name.py
+++ b/social_django/migrations/0002_add_related_name.py
@@ -12,10 +12,6 @@ USER_MODEL = getattr(settings, setting_name('USER_MODEL'), None) or \
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        ('default', '0002_add_related_name'),
-        ('social_auth', '0002_add_related_name')
-    ]
 
     dependencies = [
         ('social_django', '0001_initial'),

--- a/social_django/migrations/0003_alter_email_max_length.py
+++ b/social_django/migrations/0003_alter_email_max_length.py
@@ -10,10 +10,6 @@ EMAIL_LENGTH = getattr(settings, setting_name('EMAIL_LENGTH'), 254)
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        ('default', '0003_alter_email_max_length'),
-        ('social_auth', '0003_alter_email_max_length')
-    ]
 
     dependencies = [
         ('social_django', '0002_add_related_name'),

--- a/social_django/migrations/0004_auto_20160423_0400.py
+++ b/social_django/migrations/0004_auto_20160423_0400.py
@@ -7,10 +7,6 @@ from ..fields import JSONField
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        ('default', '0004_auto_20160423_0400'),
-        ('social_auth', '0004_auto_20160423_0400')
-    ]
 
     dependencies = [
         ('social_django', '0003_alter_email_max_length'),

--- a/social_django/migrations/0005_auto_20160727_2333.py
+++ b/social_django/migrations/0005_auto_20160727_2333.py
@@ -6,9 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        ('social_auth', '0005_auto_20160727_2333')
-    ]
 
     dependencies = [
         ('social_django', '0004_auto_20160423_0400'),


### PR DESCRIPTION
fixed it for you. By killing the 'replaces' attribute in the first 5 migrations, now upon reverting back to a previous state, the django_migrations table properly has records removed.