### PR TITLE
field.rel was renamed in django 1.9

### DIFF
--- a/social_django/compat.py
+++ b/social_django/compat.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 def get_rel_model(field):
-    if django.VERSION >= (2, 0):
+    if django.VERSION >= (1, 9):
         return field.remote_field.model
 
     user_model = field.rel.to


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/releases/1.9/#field-rel-changes

this silences the deprecation warnings