### PR TITLE
fix complete url

### DIFF
--- a/social_django/urls.py
+++ b/social_django/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     # authentication / association
     url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
         name='begin'),
-    url(r'^complete/(?P<backend>[^/]+){0}$'.format(extra), views.complete,
+    url(r'^complete/(?P<backend>\w+)$'.format(extra), views.complete,
         name='complete'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,


### PR DESCRIPTION
About QQ:  the rule of callback url was changed from 3/1 2018:the callback url can not be root path,that is it can not includes "/" at then end of url.
However,the other social websites do not have this rule,so we should change the complete url for QQ.
