### PR TITLE
utils: Stop fixing AUTHENTICATION_BACKENDS unnecessarily.

### DIFF
--- a/social_django/context_processors.py
+++ b/social_django/context_processors.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlquote
 
@@ -10,7 +11,7 @@ except ImportError:  # django < 1.4
 
 
 from social_core.backends.utils import user_backends_data
-from .utils import Storage, BACKENDS
+from .utils import Storage
 
 
 class LazyDict(SimpleLazyObject):
@@ -30,7 +31,7 @@ def backends(request):
     """Load Social Auth current user data to context under the key 'backends'.
     Will return the output of social_core.backends.utils.user_backends_data."""
     return {'backends': LazyDict(lambda: user_backends_data(request.user,
-                                                            BACKENDS,
+                                                            settings.AUTHENTICATION_BACKENDS,
                                                             Storage))}
 
 

--- a/social_django/utils.py
+++ b/social_django/utils.py
@@ -10,7 +10,6 @@ from social_core.backends.utils import get_backend
 from .compat import reverse
 
 
-BACKENDS = settings.AUTHENTICATION_BACKENDS
 STRATEGY = getattr(settings, setting_name('STRATEGY'),
                    'social_django.strategy.DjangoStrategy')
 STORAGE = getattr(settings, setting_name('STORAGE'),
@@ -24,7 +23,7 @@ def load_strategy(request=None):
 
 
 def load_backend(strategy, name, redirect_uri):
-    Backend = get_backend(BACKENDS, name)
+    Backend = get_backend(settings.AUTHENTICATION_BACKENDS, name)
     return Backend(strategy, redirect_uri)
 
 


### PR DESCRIPTION
If you're writing unit tests that test various options for
AUTHENTICATION_BACKENDS using e.g.
@override_settings(AUTHENTICATION_BACKENDS=...) or `with
self.settings(...)`, that works great in Django in general.

However, the first such test that interacts with python-social-auth
enough to cause utils.py to be imported will fix the value of
AUTHENTICATION_BACKENDS used by social-auth for the rest of the
process' lifetime.

As a result, if one first accesses it with a smaller/restrictive list
of backends, and then tries to use it with a larger list later, one
gets a 404 "Backend Not Found" error in those later accesses. So it
manifested for us as unit tests passing or failing depending on
whether our one test that sets a short list of backends ran early or
late.

The fix is simply to access settings.AUTHENTICATION_BACKENDS directly
when it needs it, rather than providing a short alias at the top of
the utils.py file.

Fixes #161.