### PR TITLE
JSONField.from_db_value: remove context kwarg

### DIFF
--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -23,7 +23,7 @@ class JSONField(JSONFieldBase):
         kwargs.setdefault('default', dict)
         super(JSONField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)
 
     def to_python(self, value):
@@ -69,4 +69,3 @@ class JSONField(JSONFieldBase):
         """Return value dumped to string."""
         orig_val = super(JSONField, self).value_from_object(obj)
         return self.get_prep_value(orig_val)
-


### PR DESCRIPTION
Fixes:

> …/django/db/models/sql/compiler.py:998:
> RemovedInDjango30Warning: Remove the context parameter from
> JSONField.from_db_value(). Support for it will be removed in Django 3.0.

Fixes https://github.com/python-social-auth/social-app-django/issues/155