### PR TITLE
feat(DjangoNonceMixin): implement 'get' and 'delete' class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/python-social-auth/social-docs/commits/master)
 
 ### Added
-- Implemnet `get` and `delete` class methods for `DjangoNonceMixin`
+- Implement `get` and `delete` class methods for `DjangoNonceMixin`
 
 ## [3.1.0](https://github.com/python-social-auth/social-app-django/releases/tag/3.1.0) - 2018-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/python-social-auth/social-docs/commits/master)
+
+### Added
+- Implemnet `get` and `delete` class methods for `DjangoNonceMixin`
+
 ## [3.1.0](https://github.com/python-social-auth/social-app-django/releases/tag/3.1.0) - 2018-10-31
 
 ### Changed

--- a/social_django/storage.py
+++ b/social_django/storage.py
@@ -150,6 +150,17 @@ class DjangoNonceMixin(NonceMixin):
                                          timestamp=timestamp,
                                          salt=salt)[1]
 
+    @classmethod
+    def get(cls, server_url, salt):
+        return cls.objects.get(
+            server_url=server_url,
+            salt=salt,
+        )
+
+    @classmethod
+    def delete(cls, nonce):
+        nonce.delete()
+
 
 class DjangoAssociationMixin(AssociationMixin):
     @classmethod


### PR DESCRIPTION
Addresses: https://github.com/python-social-auth/social-core/issues/383

Part of this PR: https://github.com/python-social-auth/social-core/pull/384 as detailed in this comment: https://github.com/python-social-auth/social-core/pull/384/files#r308203030