### PR TITLE
Fix TypeError on Django 2.1 when continuing partial pipelines

### DIFF
--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -106,11 +106,9 @@ class DjangoStrategy(BaseStrategy):
         kwargs['backend'] = backend
         return authenticate(*args, **kwargs)
 
-    def clean_authenticate_args(self, *args, **kwargs):
-        """Cleanup request argument if present, which is passed to
-        authenticate as for Django 1.11"""
-        if len(args) > 0 and isinstance(args[0], HttpRequest):
-            kwargs['request'], args = args[0], args[1:]
+    def clean_authenticate_args(self, request, *args, **kwargs):
+        # pipelines don't want a positional request argument
+        kwargs['request'] = request
         return args, kwargs
 
     def session_get(self, name, default=None):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,7 +29,7 @@ INSTALLED_APPS = [
 
 SITE_ID = 1
 
-MIDDLEWARE = MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -104,3 +104,9 @@ class TestStrategy(TestCase):
         args, kwargs = self.strategy.clean_authenticate_args(self.request)
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {'request': self.request})
+
+    def test_clean_authenticate_args_none(self):
+        # When called from continue_pipeline(), request is None. Issue #222
+        args, kwargs = self.strategy.clean_authenticate_args(None)
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs, {'request': None})

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django-18
-    {py27,py34,py35}-django-19
-    {py27,py34,py35}-django-110
     {py27,py34,py35,py36}-django-111
-    {py35,py36}-django-20
     {py35,py36,py37}-django-21
     {py35,py36,py37}-django-22
     {py36,py37}-django-master
@@ -15,19 +11,8 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/social_django
 commands = coverage run manage.py test
 deps =
-    django-18: Django>=1.8,<1.9
-    django-19: Django>=1.9,<1.10
-    django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2
-    django-20: Django>=2.0b1,<2.1
     django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<2.3
     django-master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/dev-requirements.txt
-
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7


### PR DESCRIPTION
Fixes #222

This also removes unsupported djangoes from `tox.ini`, because the test I added won't pass on Django 1.10 or lower, and the README states: 

> This project will focus on the currently supported Django releases as stated on the Django Project Supported Versions table.

... which is currently 1.11, 2.1, 2.2.