### PR TITLE
When using transaction.atomic, use the right db

### DIFF
--- a/social_django/storage.py
+++ b/social_django/storage.py
@@ -3,7 +3,7 @@ import base64
 import six
 import sys
 from django.core.exceptions import FieldDoesNotExist
-from django.db import transaction
+from django.db import transaction, router
 from django.db.utils import IntegrityError
 
 from social_core.storage import UserMixin, AssociationMixin, NonceMixin, \
@@ -75,7 +75,8 @@ class DjangoUserMixin(UserMixin):
                 # manager, there's a transaction wrapped around this call.
                 # If the create fails below due to an IntegrityError, ensure that the transaction
                 # stays undamaged by wrapping the create in an atomic.
-                with transaction.atomic():
+                using = router.db_for_write(cls.user_model())
+                with transaction.atomic(using=using):
                     user = cls.user_model().objects.create_user(*args, **kwargs)
             else:
                 user = cls.user_model().objects.create_user(*args, **kwargs)

--- a/social_django/storage.py
+++ b/social_django/storage.py
@@ -137,7 +137,8 @@ class DjangoUserMixin(UserMixin):
             # manager, there's a transaction wrapped around this call.
             # If the create fails below due to an IntegrityError, ensure that the transaction
             # stays undamaged by wrapping the create in an atomic.
-            with transaction.atomic():
+            using = router.db_for_write(cls)
+            with transaction.atomic(using=using):
                 social_auth = cls.objects.create(user=user, uid=uid, provider=provider)
         else:
             social_auth = cls.objects.create(user=user, uid=uid, provider=provider)


### PR DESCRIPTION
[Django documents](https://docs.djangoproject.com/en/2.2/topics/db/transactions/#django.db.transaction.atomic) that without a `using` parameter, `transaction.atomic` will use the `default` database. Not everyone may store their user objects in the default database though, so determine _what_ database should be used and specify it in the `using` parameter.