### PR TITLE
Add db_index=True to UserSocialAuth.uid field

### DIFF
--- a/social_django/migrations/0009_uid_db_index.py
+++ b/social_django/migrations/0009_uid_db_index.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import models, migrations
+
+from social_core.utils import setting_name
+
+UID_LENGTH = getattr(settings, setting_name('UID_LENGTH'), 255)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('social_django', '0008_partial_timestamp'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='usersocialauth',
+            name='uid',
+            field=models.CharField(max_length=UID_LENGTH, db_index=True),
+        ),
+    ]

--- a/social_django/models.py
+++ b/social_django/models.py
@@ -33,7 +33,7 @@ class AbstractUserSocialAuth(models.Model, DjangoUserMixin):
     user = models.ForeignKey(USER_MODEL, related_name='social_auth',
                              on_delete=models.CASCADE)
     provider = models.CharField(max_length=32)
-    uid = models.CharField(max_length=UID_LENGTH)
+    uid = models.CharField(max_length=UID_LENGTH, db_index=True)
     extra_data = JSONField()
     objects = UserSocialAuthManager()
 


### PR DESCRIPTION
in case unique_together does add (function as) an index
(e.g. Postgres) it will be a multiple column index. If you want
one of the columns to be indexed individually you need to specify
db_index=True.

Backgroud: we've got an app which already handles social login via GitHub and will also start receiving GitHub webhooks. The only solid piece of identifier is the GitHub user ID which is the `uid` field. 

