### PR TITLE
Increase social-core version to pick up change made in response to a …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-social-auth-core >= 3.2.0
+social-auth-core >= 3.3.0


### PR DESCRIPTION
…deprecated OAuth API on GitHub.com

https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

GitHub is deprecating authentication to the GitHub API using query parameters, such as using a access_token query parameter .......

https://developer.github.com/v3/auth/#basic-authentication


Fixed with social-core v3.3.0 with PR #428
https://github.com/python-social-auth/social-core/pull/428