### PR TITLE
Update JSONField for django 3.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use query `.exists()` instead of `.count() > 0`
 - Added testing for Django 3.0
 - Drop support for Python 2
+- JSONField support for #265
+
+  Django 3.1 introduces JSONField support for all backends and adds a deprecation
+  warning.
+
+  - Deprecating setting: `SOCIAL_AUTH_POSTGRES_JSONFIELD` (bool)
+
+    Rename this to `SOCIAL_AUTH_JSONFIELD_ENABLED`. The setting will be deprecated in a future release.
+
+  - New setting: `SOCIAL_AUTH_JSONFIELD_ENABLED` (bool)
+
+    Same behavior, setting name updated to match JSONField being supported by all systems.
+
+    ```python
+    SOCIAL_AUTH_POSTGRES_JSONFIELD = True   # Before
+    SOCIAL_AUTH_JSONFIELD_ENABLED = True    # After
+    ```
+
+  - New setting: `SOCIAL_AUTH_JSONFIELD_CUSTOM` allows specifying an import string.
+    This gives better control to social auth with setting a custom JSONField.
+
+    For django systems < 3.1 (technically <4), you can set the old JSONField to maintain
+    behavior with earlier social-app-django releases:
+
+    `SOCIAL_AUTH_JSONFIELD_CUSTOM = 'django.contrib.postgres.fields.JSONField'`
+
+    For sites running or upgrading to django 3.1+, then can set this so the new value:
+
+    `SOCIAL_AUTH_JSONFIELD_CUSTOM = 'django.db.models.JSONField'`
+
+  [#266](https://github.com/omab/python-social-auth/pull/266) for issue [#265](https://github.com/omab/python-social-auth/pull/265)
 
 ## [4.0.0](https://github.com/python-social-auth/social-app-django/releases/tag/4.0.0) - 2020-06-20
 

--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from django.core.exceptions import ValidationError
 from django.conf import settings
@@ -7,8 +8,30 @@ from django.utils.encoding import force_str
 
 from social_core.utils import setting_name
 
-if getattr(settings, setting_name('POSTGRES_JSONFIELD'), False):
-    from django.contrib.postgres.fields import JSONField as JSONFieldBase
+POSTGRES_JSONFIELD = getattr(settings, setting_name('POSTGRES_JSONFIELD'), False)
+
+if POSTGRES_JSONFIELD:
+    warnings.warn(
+        'SOCIAL_AUTH_POSTGRES_JSONFIELD has been renamed to '
+        'SOCIAL_AUTH_JSONFIELD_ENABLED and will be removed in the next release.'
+    )
+    JSONFIELD_ENABLED = True
+else:
+    JSONFIELD_ENABLED = getattr(settings, setting_name('JSONFIELD_ENABLED'), False)
+
+if JSONFIELD_ENABLED:
+    JSONFIELD_CUSTOM = getattr(settings, setting_name('JSONFIELD_CUSTOM'), None)
+    if JSONFIELD_CUSTOM is not None:
+        try:
+            from django.utils.module_loading import import_string as import_module
+        except ImportError:
+            from importlib import import_module
+        JSONFieldBase = import_module(JSONFIELD_CUSTOM)
+    else:
+        try:
+            from django.db.models import JSONField as JSONFieldBase
+        except ImportError:
+            from django.contrib.postgres.fields import JSONField as JSONFieldBase
 else:
     JSONFieldBase = models.TextField
 


### PR DESCRIPTION
**Update 2020-09-06: I am not using this project anymore (due an outside reason, this project is fine). If there are edits needed that the maintainer can't add, feel free to fork [my branch](https://github.com/tony/social-app-django/tree/fix-jsonfield-import) / make your own branch and PR it. I apologize about this!**

Django 3.1 has a universal JSONField in `django.db.models`.
It raises a deprecation warning for JSONField imported via
`django.contrib.postgres`. Django 4.x removes it completely.

Preserve compatibility with older versions, import via compat module.
Hopefully this preserves migration compatibility.

Fixes #265

Also adds django 3.0 and 3.1 to CI - ignores `master` (which can fail sporadically)

# Changes

## CI

Add support for django 3.0 and 3.1 

## Settings

Django 3.1 introduces JSONField support for all backends and adds a deprecation
warning.

- Deprecating setting: `SOCIAL_AUTH_POSTGRES_JSONFIELD` (bool)

  Rename this to `SOCIAL_AUTH_JSONFIELD_ENABLED`. The setting will be deprecated in a future release.

- New setting: `SOCIAL_AUTH_JSONFIELD_ENABLED` (bool)

  Same behavior, setting name updated to match JSONField being supported by all systems.

- New setting: `SOCIAL_AUTH_JSONFIELD_CUSTOM` allows specifying an import string. This gives better control of the `JSONField` used by social-app-django.

  For django systems 3.1+, `django.db.models.JSONField` will be used by default. Older systems will fall back to `django.contrib.postgres.fields.JSONField`

  django 4.0': `django.contrib.postgres.fields.JSONField` [will still exist for import migrations](https://github.com/django/django/commit/7cb5712edc158396c9d4fbf1ecf17794d9a128b3#diff-f52b45a9d9ef14afdc1380fa97221caefb7ef3c9e71e67464d9719a91a87e64e)

  At any time, you can set to a custom JSONField of your own with, e.g.:

  `SOCIAL_AUTH_JSONFIELD_CUSTOM = 'django.contrib.postgres.fields.JSONField'`