### PR TITLE
Fix deprecation warning about default_app_config from Django 3.4+

### DIFF
--- a/social_django/__init__.py
+++ b/social_django/__init__.py
@@ -1,6 +1,7 @@
 __version__ = '4.0.0'
 
 
+import django
 from social_core.backends.base import BaseAuth
 
 # django.contrib.auth.load_backend() will import and instanciate the
@@ -21,4 +22,5 @@ if not getattr(BaseAuth, '__init_patched', False):
     BaseAuth.__init__ = baseauth_init_workaround(BaseAuth.__init__)
     BaseAuth.__init_patched = True
 
-default_app_config = 'social_django.config.PythonSocialAuthConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'social_django.apps.PythonSocialAuthConfig'

--- a/social_django/apps.py
+++ b/social_django/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class PythonSocialAuthConfig(AppConfig):
+    # Full Python path to the application eg. 'django.contrib.admin'.
+    name = 'social_django'
+    # Last component of the Python path to the application eg. 'admin'.
+    label = 'social_django'
+    # Human-readable name for the application eg. "Admin".
+    verbose_name = 'Python Social Auth'

--- a/social_django/config.py
+++ b/social_django/config.py
@@ -1,10 +1,2 @@
-from django.apps import AppConfig
-
-
-class PythonSocialAuthConfig(AppConfig):
-    # Full Python path to the application eg. 'django.contrib.admin'.
-    name = 'social_django'
-    # Last component of the Python path to the application eg. 'admin'.
-    label = 'social_django'
-    # Human-readable name for the application eg. "Admin".
-    verbose_name = 'Python Social Auth'
+# For backward compatibility. You should use the configuration from apps module
+from .apps import PythonSocialAuthConfig


### PR DESCRIPTION
The PythonSocialAuthConfig class is moved to apps module so that
Django finds it automatically.

## Proposed changes

Fix deprecation warning from Django 3.4+ about default_app_config

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
