### PR TITLE
Remove references to nose testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
-nosetests.xml
 
 # Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,3 @@
 max-line-length = 119
 # Ignore some well known paths
 exclude = .venv,.tox,dist,doc,build,*.egg,db/env.py,db/versions/*.py,site
-
-[nosetests]
-verbosity=2
-with-coverage=1
-cover-erase=1
-cover-package=social
-rednose=1


### PR DESCRIPTION
## Proposed changes

It seems nose has not been used since 77a3ec42468640dd67086e6afba3375cb7ae8135, so these final references in configuration can be removed.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Other information

n/a