### PR TITLE
Fix The Bug Of The Related Name 

### DIFF
--- a/social_django/models.py
+++ b/social_django/models.py
@@ -37,7 +37,7 @@ class AbstractUserSocialAuth(models.Model, DjangoUserMixin):
     """Abstract Social Auth association model"""
 
     user = models.ForeignKey(
-        USER_MODEL, related_name="social_auth", on_delete=models.CASCADE
+        USER_MODEL, related_name="abstract_social_auth", on_delete=models.CASCADE
     )
     provider = models.CharField(max_length=32)
     uid = models.CharField(max_length=UID_LENGTH, db_index=True)


### PR DESCRIPTION
In Django Version 4 when I tried using this module I faced a bug like this TypeError: Direct assignment to the reverse side of a related set is prohibited. Use social_auth.set() instead.

I noticed that the "social_auth" related name in Django v4 makes the problem So I Forced to clon this app and edit that

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
