### PR TITLE
Pin `social-auth-core` to fix missing `jose` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-social-auth-core >= 4.1.0
+social-auth-core>=4.3,<4.4


### PR DESCRIPTION
Closes #427 