### PR TITLE
Add configuration to require POST only authentication requsts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ changelog.sh
 .python-version
 
 files/local.env
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Uses Django native JSON field
+- Introduce configuration to request POST only requests for social authentication
 
 ## [5.2.0](https://github.com/python-social-auth/social-app-django/releases/tag/5.2.0) - 2023-03-31
 

--- a/social_django/utils.py
+++ b/social_django/utils.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, HttpResponseNotAllowed
 from django.urls import reverse
 from social_core.exceptions import MissingBackend
 from social_core.utils import get_strategy, module_member, setting_name
@@ -12,6 +12,8 @@ STRATEGY = getattr(
 STORAGE = getattr(
     settings, setting_name("STORAGE"), "social_django.models.DjangoStorage"
 )
+REQUIRE_POST = setting_name("REQUIRE_POST")
+
 Strategy = module_member(STRATEGY)
 Storage = module_member(STORAGE)
 
@@ -48,3 +50,15 @@ def psa(redirect_uri=None, load_strategy=load_strategy):
         return wrapper
 
     return decorator
+
+
+def maybe_require_post(func):
+    @wraps(func)
+    def wrapper(request, backend, *args, **kwargs):
+        require_post = getattr(settings, REQUIRE_POST, False)
+        if require_post and request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        return func(request, backend, *args, **kwargs)
+
+    return wrapper

--- a/social_django/utils.py
+++ b/social_django/utils.py
@@ -1,8 +1,9 @@
 from functools import wraps
 
 from django.conf import settings
-from django.http import Http404, HttpResponseNotAllowed
+from django.http import Http404
 from django.urls import reverse
+from django.views.decorators.http import require_POST
 from social_core.exceptions import MissingBackend
 from social_core.utils import get_strategy, module_member, setting_name
 
@@ -56,8 +57,8 @@ def maybe_require_post(func):
     @wraps(func)
     def wrapper(request, backend, *args, **kwargs):
         require_post = getattr(settings, REQUIRE_POST, False)
-        if require_post and request.method != "POST":
-            return HttpResponseNotAllowed(["POST"])
+        if require_post:
+            return require_POST(func)(request, backend, *args, **kwargs)
 
         return func(request, backend, *args, **kwargs)
 

--- a/social_django/views.py
+++ b/social_django/views.py
@@ -11,7 +11,7 @@ from social_core.utils import setting_name
 from .utils import psa
 
 NAMESPACE = getattr(settings, setting_name("URL_NAMESPACE"), None) or "social"
-REQUIRE_POST = getattr(settings, setting_name("REQUIRE_POST"), False)
+REQUIRE_POST_CONFIG_NAME = setting_name("REQUIRE_POST")
 
 # Calling `session.set_expiry(None)` results in a session lifetime equal to
 # platform default session lifetime.
@@ -21,7 +21,8 @@ DEFAULT_SESSION_TIMEOUT = None
 @never_cache
 @psa(f"{NAMESPACE}:complete")
 def auth(request, backend):
-    if REQUIRE_POST and request.method != "POST":
+    require_post = getattr(settings, REQUIRE_POST_CONFIG_NAME, False)
+    if require_post and request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
 
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)

--- a/social_django/views.py
+++ b/social_django/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_POST
 from social_core.actions import do_auth, do_complete, do_disconnect
 from social_core.utils import setting_name
 
-from .utils import psa, maybe_require_post
+from .utils import maybe_require_post, psa
 
 NAMESPACE = getattr(settings, setting_name("URL_NAMESPACE"), None) or "social"
 

--- a/social_django/views.py
+++ b/social_django/views.py
@@ -1,17 +1,15 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseNotAllowed
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_POST
 from social_core.actions import do_auth, do_complete, do_disconnect
 from social_core.utils import setting_name
 
-from .utils import psa
+from .utils import psa, maybe_require_post
 
 NAMESPACE = getattr(settings, setting_name("URL_NAMESPACE"), None) or "social"
-REQUIRE_POST_CONFIG_NAME = setting_name("REQUIRE_POST")
 
 # Calling `session.set_expiry(None)` results in a session lifetime equal to
 # platform default session lifetime.
@@ -19,12 +17,9 @@ DEFAULT_SESSION_TIMEOUT = None
 
 
 @never_cache
+@maybe_require_post
 @psa(f"{NAMESPACE}:complete")
 def auth(request, backend):
-    require_post = getattr(settings, REQUIRE_POST_CONFIG_NAME, False)
-    if require_post and request.method != "POST":
-        return HttpResponseNotAllowed(["POST"])
-
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
 
 

--- a/social_django/views.py
+++ b/social_django/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseNotAllowed
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_POST
@@ -10,6 +11,7 @@ from social_core.utils import setting_name
 from .utils import psa
 
 NAMESPACE = getattr(settings, setting_name("URL_NAMESPACE"), None) or "social"
+REQUIRE_POST = getattr(settings, setting_name("REQUIRE_POST"), False)
 
 # Calling `session.set_expiry(None)` results in a session lifetime equal to
 # platform default session lifetime.
@@ -19,6 +21,9 @@ DEFAULT_SESSION_TIMEOUT = None
 @never_cache
 @psa(f"{NAMESPACE}:complete")
 def auth(request, backend):
+    if REQUIRE_POST and request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -26,6 +26,13 @@ class TestViews(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
+    def test_require_post_works(self):
+        with override_settings(SOCIAL_AUTH_REQUIRE_POST=True):
+            response = self.client.get(
+                reverse("social:begin", kwargs={"backend": "facebook"})
+            )
+            self.assertEqual(response.status_code, 405)
+
     @mock.patch("social_core.backends.base.BaseAuth.request")
     def test_complete(self, mock_request):
         url = reverse("social:complete", kwargs={"backend": "facebook"})


### PR DESCRIPTION
## Proposed changes

This PR introduces a new configuration and authentication behaviour when it is active and will require POST request during authentication

* Configuration key is `SOCIAL_AUTH_REQUIRE_POST: bool`,
* Error response if request method is not `POST`.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Related issues and discussions

* https://github.com/python-social-auth/social-app-django/issues/486
* https://github.com/python-social-auth/social-app-django/issues/55

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
