### PR TITLE
Fix ImportError: cannot import name 'JSONField' from 'social_django.fields' when  JSONFIELD_CUSTOM is set

### DIFF
--- a/social_django/fields.py
+++ b/social_django/fields.py
@@ -21,7 +21,7 @@ if JSONFIELD_ENABLED:
             from django.utils.module_loading import import_string
         except ImportError:
             from importlib import import_module as import_string
-        JSONFieldBase = import_string(JSONFIELD_CUSTOM)
+        JSONField = import_string(JSONFIELD_CUSTOM)
     else:
         try:
             from django.db.models import JSONField


### PR DESCRIPTION
When setting JSONFIELD_CUSTOM the logic was importing under the wrong name with `Base` suffix raising `Import Error` as the module ended up having no `JSONField` to be imported.

Looks like due to a  recent change the JSONFieldBase` is no more needed.
