### PR TITLE
Avoid raising errors on malformed POST data

### DIFF
--- a/social_django/context_processors.py
+++ b/social_django/context_processors.py
@@ -2,6 +2,7 @@ from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http.multipartparser import MultiPartParserError
 from django.utils.functional import SimpleLazyObject
 
 try:
@@ -45,11 +46,15 @@ def backends(request):
 
 def login_redirect(request):
     """Load current redirect to context."""
-    value = (
-        request.method == "POST"
-        and request.POST.get(REDIRECT_FIELD_NAME)
-        or request.GET.get(REDIRECT_FIELD_NAME)
-    )
+    try:
+        value = (
+            request.method == "POST"
+            and request.POST.get(REDIRECT_FIELD_NAME)
+            or request.GET.get(REDIRECT_FIELD_NAME)
+        )
+    except MultiPartParserError:
+        # request POST may be malformed
+        value = None
     if value:
         value = quote(value)
         querystring = REDIRECT_FIELD_NAME + "=" + value

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -19,3 +19,17 @@ class TestContextProcessors(TestCase):
                 "REDIRECT_QUERYSTRING": "next=profile/sj%C3%B3",
             },
         )
+
+    def test_login_redirect_malformed_post(self):
+        request = self.request_factory.post(
+            "/", data="no boundary", content_type="multipart/form-data"
+        )
+        result = login_redirect(request)
+        self.assertEqual(
+            result,
+            {
+                "REDIRECT_FIELD_NAME": "next",
+                "REDIRECT_FIELD_VALUE": None,
+                "REDIRECT_QUERYSTRING": "",
+            },
+        )


### PR DESCRIPTION
## Proposed changes

The `login_redirect` context-processor relies on `request.POST` data to retrive the redirect field value.

If by any means the django app is serving a malformed multipart request (ie: `Content-Type: multipart/form-data` without a proper form-boundary) it will raise a multipart error. Since this context-processor is advised to be used in the default template configuration it will cause a 500 response (internal server error) due to the un-catched exception.

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist


- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

