### PR TITLE
Increase social-core version to 4.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=3.2
-social-auth-core>=4.4.1
+social-auth-core>=4.5.2


### PR DESCRIPTION
updated `social-core` version to 4.5.2.
Details are here.
https://github.com/python-social-auth/social-app-django/issues/550