### PR TITLE
Fixed rollback of extra_data migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fixed `UserSocialAuth` creation by allowing `JSONField` to be blank
 - Fixed the assumption that UID can only be an integer (#571)
+- Fixed revert of migration `0013_migrate_extra_data.py`
 
 ## [5.4.1](https://github.com/python-social-auth/social-app-django/releases/tag/5.4.1) - 2024-04-24
 

--- a/social_django/migrations/0013_migrate_extra_data.py
+++ b/social_django/migrations/0013_migrate_extra_data.py
@@ -67,7 +67,7 @@ def migrate_json_field_backwards(apps, schema_editor):
         to_be_updated.clear()
 
     is_text_field = issubclass(
-        Partial._meta.get_field("data"),
+        type(Partial._meta.get_field("data")),
         models.TextField,
     )
     for auth in Partial.objects.using(db_alias).all():


### PR DESCRIPTION
## Proposed changes

The `extra_data` json field migration `0013_migrate_extra_data.py` was not revertable since the `is_text_field` type check was throwing a TypeError since the first argument is an instance instead of a class. This error occurs only when reverting migrations on databases other than SQLite.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs
