### PR TITLE
fix(models): remove app_name from abstract models

### DIFF
--- a/social_django/models.py
+++ b/social_django/models.py
@@ -42,7 +42,6 @@ class AbstractUserSocialAuth(models.Model, DjangoUserMixin):
         return str(self.user)
 
     class Meta:
-        app_label = "social_django"
         abstract = True
 
     @classmethod


### PR DESCRIPTION
When a subclass doesn't overrider Meta, it inherits the app_name from the abstract class what is not descired behavior as it lands migrations into social_django instead of the actuall app.

Fixes #496

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
