### PR TITLE
chore: drop support for Django 4.2, 5.0 and Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
@@ -44,16 +43,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox coverage
-
-    - name: Django 4.2.x Test
-      run: |
-        tox -e "py${PYTHON_VERSION/\./}-django42"
-      if: ${{ env.PYTHON_VERSION == '3.9' || env.PYTHON_VERSION == '3.10' || env.PYTHON_VERSION == '3.11' }}
-
-    - name: Django 5.0.x Test
-      run: |
-        tox -e "py${PYTHON_VERSION/\./}-django50"
-      if: ${{ env.PYTHON_VERSION == '3.10' || env.PYTHON_VERSION == '3.11' || env.PYTHON_VERSION == '3.12' || env.PYTHON_VERSION == '3.13' }}
 
     - name: Django 5.1.x Test
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,13 @@ repos:
   rev: v1.6.0
   hooks:
   - id: zizmor
+- repo: https://github.com/adamchainz/djade-pre-commit
+  rev: 1.4.0
+  hooks:
+  - id: djade
+    args: [--target-version, '5.1']
+- repo: https://github.com/adamchainz/django-upgrade
+  rev: 1.24.0
+  hooks:
+  - id: django-upgrade
+    args: [--target-version, '5.1']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python",
   "Topic :: Internet"
 ]
 dependencies = [
-  "Django>=4.2",
+  "Django>=5.1",
   "social-auth-core~=4.4"
 ]
 description = "Python Social Authentication, Django integration."
@@ -41,7 +40,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 name = "social-auth-app-django"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 version = "5.4.3"
 
 [project.optional-dependencies]
@@ -86,7 +85,7 @@ plugins = [
 ]
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportAttributeAccessIssue = "none"
 reportOptionalMemberAccess = "none"
 reportPossiblyUnboundVariable = "none"
@@ -106,7 +105,6 @@ exclude = [
 ]
 line-length = 120
 output-format = "github"
-target-version = "py37"
 
 [tool.ruff.lint]
 ignore = []

--- a/social_django/models.py
+++ b/social_django/models.py
@@ -1,7 +1,5 @@
 """Django ORM models for Social Auth"""
 
-from typing import Union
-
 from django.conf import settings
 from django.db import models
 from django.db.utils import IntegrityError
@@ -45,7 +43,7 @@ class AbstractUserSocialAuth(models.Model, DjangoUserMixin):
         abstract = True
 
     @classmethod
-    def get_social_auth(cls, provider: str, uid: Union[str, int]):
+    def get_social_auth(cls, provider: str, uid: str | int):
         if not isinstance(uid, str):
             uid = str(uid)
         for social in cls.objects.select_related("user").filter(provider=provider, uid=uid):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    py{39,310,311}-django42
-    py{310,311,312,313}-django50
     py{310,311,312,313}-django51
     py{310,311,312,313}-django52
     py{312,313}-djangomain
@@ -12,10 +10,8 @@ passenv = *
 commands =
     coverage run manage.py test
 deps =
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
-    django52: Django>=5.2a1,<5.3
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
     socialmaster: https://github.com/python-social-auth/social-core/archive/master.tar.gz
     .[dev]


### PR DESCRIPTION
- Django 5.0 is no longer supported upstream.
- Django 4.2 is still LTS, but it is no longer possible to keep compatibility with upcoming Django 6 and 4.2 (see #557).
- Python 3.9 was supported only with Django 4.2.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
