### PR TITLE
Fix LoginRequiredMiddleware compatibility

### DIFF
--- a/social_django/views.py
+++ b/social_django/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, login
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_not_required, login_required
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_POST
@@ -17,6 +17,7 @@ DEFAULT_SESSION_TIMEOUT = None
 
 
 @never_cache
+@login_not_required
 @maybe_require_post
 @psa(f"{NAMESPACE}:complete")
 def auth(request, backend):
@@ -24,6 +25,7 @@ def auth(request, backend):
 
 
 @never_cache
+@login_not_required
 @csrf_exempt
 @psa(f"{NAMESPACE}:complete")
 def complete(request, backend, *args, **kwargs):


### PR DESCRIPTION
Django 5.1 introduced the LoginRequiredMiddleware which flips around the defaults for view authentication which breaks the login views for apps that use the middleware.
This decorates the login views explicitly with login_not_required.

Fixes #713

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
