### PR TITLE
feat: add async support to SocialAuthExceptionMiddleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
   "Topic :: Internet"
 ]
 dependencies = [
+  "asgiref>=3.8.1",
   "Django>=5.2",
   "social-auth-core~=4.8.3"
 ]

--- a/social_django/middleware.py
+++ b/social_django/middleware.py
@@ -1,14 +1,17 @@
 from urllib.parse import quote
 
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
 from django.shortcuts import redirect
+from django.utils.decorators import sync_and_async_middleware
 from social_core.exceptions import SocialAuthBaseException
 from social_core.utils import social_logger
 
 
+@sync_and_async_middleware
 class SocialAuthExceptionMiddleware:
     """
     Middleware that handles Social Auth AuthExceptions by providing the user
@@ -24,6 +27,9 @@ class SocialAuthExceptionMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
+
+        if iscoroutinefunction(get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
         return self.get_response(request)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,11 +1,14 @@
 import logging
 from unittest import mock
 
+from asgiref.sync import iscoroutinefunction
 from django.contrib.messages import MessageFailure
-from django.http import HttpResponseRedirect
-from django.test import TestCase, override_settings
+from django.http import HttpResponse, HttpResponseRedirect
+from django.test import AsyncRequestFactory, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from social_core.exceptions import AuthCanceled
+
+from social_django.middleware import SocialAuthExceptionMiddleware
 
 
 class MockAuthCanceled(AuthCanceled):
@@ -24,6 +27,32 @@ class TestMiddleware(TestCase):
 
         self.complete_url = reverse("social:complete", kwargs={"backend": "facebook"})
         self.complete_url += "?code=2&state=1"
+
+    def test_sync_middleware(self, mocked):
+        expected = HttpResponse()
+        get_response = mock.Mock(return_value=expected)
+        rf = RequestFactory()
+        request = rf.get("/")
+
+        middleware = SocialAuthExceptionMiddleware(get_response)
+        resp = middleware(request)
+
+        self.assertFalse(iscoroutinefunction(middleware))
+        self.assertIs(resp, expected)
+        get_response.assert_called_once_with(request)
+
+    async def test_async_middleware(self, mocked):
+        expected = HttpResponse()
+        get_response = mock.AsyncMock(return_value=expected)
+        async_rf = AsyncRequestFactory()
+        request = async_rf.get("/")
+
+        middleware = SocialAuthExceptionMiddleware(get_response)
+        resp = await middleware(request)
+
+        self.assertTrue(iscoroutinefunction(middleware))
+        self.assertIs(resp, expected)
+        get_response.assert_awaited_once_with(request)
 
     def test_exception(self, mocked):
         with self.assertRaises(MockAuthCanceled):


### PR DESCRIPTION
## Problem

In ASGI/async Django projects, `SocialAuthExceptionMiddleware` was sync-only. Django detects this and automatically wraps the middleware call in `sync_to_async`, which spawns a new thread for every request via the thread pool executor. This defeats the purpose of running an async stack and can become a bottleneck under load.

## Solution

Apply Django's `@sync_and_async_middleware` decorator and use `asgiref`'s `iscoroutinefunction` / `markcoroutinefunction` to let the middleware detect whether it was instantiated with an async `get_response` callable. When it is, Django treats the middleware as natively async and no thread-pool context switch is needed.

The sync path is completely unchanged, so there is no risk of regression for WSGI deployments.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
