### PR TITLE
feat!: confirm external partial pipeline resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Security
+
+- Added the default Django confirmation page for externally resumed partial
+  pipelines and raised the `social-auth-core` dependency to the next major
+  release with the required Strategy hooks.
+
 ## [5.9.0](https://github.com/python-social-auth/social-app-django/releases/tag/5.9.0) - 2026-04-29
 
 ### Changed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include social_django *.py
+recursive-include social_django/templates *.html
 recursive-include tests *.py
 include manage.py
 include *.txt CHANGELOG.md LICENSE README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
   "asgiref>=3.8.1",
   "Django>=5.2",
-  "social-auth-core>=4.8.3,<5.0.0"
+  "social-auth-core>=5.0.0,<6.0.0"
 ]
 description = "Python Social Authentication, Django integration."
 keywords = ["django", "oauth", "openid", "saml", "social auth"]

--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -8,16 +8,23 @@ from django.contrib.auth import authenticate, get_user
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import redirect, resolve_url
+from django.shortcuts import redirect, render, resolve_url
 from django.template import TemplateDoesNotExist, engines, loader
 from django.utils.crypto import get_random_string
+from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.translation import get_language
 from social_core.strategy import BaseStrategy, BaseTemplateStrategy
+from social_core.utils import PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME
 
 if TYPE_CHECKING:
     from django.contrib.sessions.backends.base import SessionBase
+    from social_core.backends.base import BaseAuth
+    from social_core.storage import PartialMixin
+
+
+PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER = "partial_pipeline_confirm_nonce"
 
 
 def render_template_string(request, html, context=None):
@@ -117,6 +124,55 @@ class DjangoStrategy(BaseStrategy):
     def html(self, content):
         return HttpResponse(content, content_type="text/html;charset=UTF-8")
 
+    def partial_pipeline_external_resume_confirmation(
+        self,
+        backend: BaseAuth,
+        partial: PartialMixin,
+        request_data: dict[str, Any],
+    ) -> HttpResponse | None:
+        if not self.request:
+            return None
+
+        nonce = self.random_string(32)
+        self.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, nonce)
+        confirmation_parameter = backend.setting(
+            "PARTIAL_PIPELINE_EXTERNAL_RESUME_CONFIRMATION_PARAMETER",
+            "partial_pipeline_confirm",
+        )
+        return render(
+            self.request,
+            "social_django/partial_pipeline_external_resume.html",
+            {
+                "action_url": self.request.path,
+                "backend": backend,
+                "backend_name": backend.name,
+                "confirmation_parameter": confirmation_parameter,
+                "confirmation_value": "1",
+                "confirmation_nonce_parameter": (PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER),
+                "confirmation_nonce": nonce,
+                "partial": partial,
+            },
+        )
+
+    def partial_pipeline_external_resume_confirmed(
+        self,
+        backend: BaseAuth,
+        request_data: dict[str, Any],
+    ) -> bool:
+        if not self.request or self.request.method != "POST":
+            return False
+
+        confirmation_parameter = backend.setting(
+            "PARTIAL_PIPELINE_EXTERNAL_RESUME_CONFIRMATION_PARAMETER",
+            "partial_pipeline_confirm",
+        )
+        if not confirmation_parameter or confirmation_parameter not in request_data:
+            return False
+
+        expected_nonce = self.session_get(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME)
+        submitted_nonce = request_data.get(PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER)
+        return bool(expected_nonce) and submitted_nonce == expected_nonce
+
     def render_html(self, tpl=None, html=None, context=None):
         if not tpl and not html:
             msg = "Missing template or html parameters"
@@ -166,7 +222,9 @@ class DjangoStrategy(BaseStrategy):
         Converts values that are instance of Model to a dictionary
         with enough information to retrieve the instance back later.
         """
-        if isinstance(val, Model):
+        if isinstance(val, MultiValueDict):
+            val = val.dict()
+        elif isinstance(val, Model):
             val = {"pk": val.pk, "ctype": ContentType.objects.get_for_model(val).pk}
         return val
 

--- a/social_django/templates/social_django/partial_pipeline_external_resume.html
+++ b/social_django/templates/social_django/partial_pipeline_external_resume.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Continue authentication</title>
+  </head>
+  <body>
+    <form method="post" action="{{ action_url }}">
+      {% csrf_token %}
+      <input type="hidden" name="{{ confirmation_parameter }}" value="{{ confirmation_value }}">
+      <input type="hidden" name="{{ confirmation_nonce_parameter }}" value="{{ confirmation_nonce }}">
+      <button type="submit">Continue authentication</button>
+    </form>
+  </body>
+</html>

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -6,7 +6,9 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse, QueryDict
 from django.test import RequestFactory, TestCase
 from django.utils.translation import gettext_lazy
+from social_core.utils import PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME
 
+from social_django.strategy import PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER
 from social_django.utils import load_backend, load_strategy
 
 
@@ -59,6 +61,21 @@ class TestStrategy(TestCase):
         instance = self.strategy.from_session_value(val=val)
         self.assertEqual(instance, user)
 
+    def test_session_value_flattens_request_data(self):
+        request = self.request_factory.get(
+            "/complete/facebook/",
+            data={"partial_token": "external-token", "verification_code": "code"},
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+
+        val = strategy.to_session_value(strategy.request_data())
+
+        self.assertEqual(
+            val,
+            {"partial_token": "external-token", "verification_code": "code"},
+        )
+
     def test_get_language(self):
         self.assertEqual(self.strategy.get_language(), "en-us")
 
@@ -82,6 +99,142 @@ class TestStrategy(TestCase):
 
         result = self.strategy.tpl.render_string(html="xoxo", context=ctx)
         self.assertEqual(result, "xoxo")
+
+    def test_partial_pipeline_external_resume_confirmation(self):
+        request = self.request_factory.get(
+            "/complete/facebook/",
+            data={"partial_token": "external-token", "verification_code": "code"},
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+
+        response = strategy.partial_pipeline_external_resume_confirmation(backend, mock.Mock(), strategy.request_data())
+
+        self.assertIsInstance(response, HttpResponse)
+        nonce = strategy.session_get(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME)
+        self.assertTrue(nonce)
+        content = response.content.decode()
+        self.assertIn('action="/complete/facebook/"', content)
+        self.assertIn('name="partial_pipeline_confirm"', content)
+        self.assertIn(f'name="{PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER}"', content)
+        self.assertIn(f'value="{nonce}"', content)
+        self.assertNotIn("partial_token", content)
+        self.assertNotIn("verification_code", content)
+
+    def test_partial_pipeline_external_resume_confirmation_uses_custom_parameter(self):
+        request = self.request_factory.get("/complete/facebook/")
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+
+        with self.settings(SOCIAL_AUTH_PARTIAL_PIPELINE_EXTERNAL_RESUME_CONFIRMATION_PARAMETER="continue_auth"):
+            response = strategy.partial_pipeline_external_resume_confirmation(
+                backend, mock.Mock(), strategy.request_data()
+            )
+
+        content = response.content.decode()
+        self.assertIn('name="continue_auth"', content)
+        self.assertNotIn('name="partial_pipeline_confirm"', content)
+        self.assertIn(f'name="{PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER}"', content)
+
+    def test_partial_pipeline_external_resume_confirmed(self):
+        request = self.request_factory.post(
+            "/complete/facebook/",
+            data={
+                "partial_pipeline_confirm": "1",
+                PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER: "nonce",
+            },
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertTrue(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
+
+    def test_partial_pipeline_external_resume_confirmed_uses_custom_parameter(self):
+        request = self.request_factory.post(
+            "/complete/facebook/",
+            data={
+                "continue_auth": "1",
+                PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER: "nonce",
+            },
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        with self.settings(SOCIAL_AUTH_PARTIAL_PIPELINE_EXTERNAL_RESUME_CONFIRMATION_PARAMETER="continue_auth"):
+            self.assertTrue(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
+
+    def test_partial_pipeline_external_resume_confirmation_without_request(self):
+        strategy = load_strategy()
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+
+        self.assertIsNone(strategy.partial_pipeline_external_resume_confirmation(backend, mock.Mock(), {}))
+
+    def test_partial_pipeline_external_resume_confirmed_without_request(self):
+        strategy = load_strategy()
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertFalse(
+            strategy.partial_pipeline_external_resume_confirmed(
+                backend,
+                {
+                    "partial_pipeline_confirm": "1",
+                    PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER: "nonce",
+                },
+            )
+        )
+
+    def test_partial_pipeline_external_resume_confirmation_rejects_get(self):
+        strategy = load_strategy(request=self.request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertFalse(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
+
+    def test_partial_pipeline_external_resume_confirmation_rejects_missing_parameter(self):
+        request = self.request_factory.post(
+            "/complete/facebook/",
+            data={PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER: "nonce"},
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertFalse(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
+
+    def test_partial_pipeline_external_resume_confirmation_rejects_missing_nonce(self):
+        request = self.request_factory.post(
+            "/complete/facebook/",
+            data={"partial_pipeline_confirm": "1"},
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertFalse(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
+
+    def test_partial_pipeline_external_resume_confirmation_rejects_wrong_nonce(self):
+        request = self.request_factory.post(
+            "/complete/facebook/",
+            data={
+                "partial_pipeline_confirm": "1",
+                PARTIAL_PIPELINE_CONFIRMATION_NONCE_PARAMETER: "wrong",
+            },
+        )
+        SessionMiddleware(lambda: None).process_request(request)
+        strategy = load_strategy(request=request)
+        backend = load_backend(strategy=strategy, name="facebook", redirect_uri="/")
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+
+        self.assertFalse(strategy.partial_pipeline_external_resume_confirmed(backend, strategy.request_data()))
 
     def test_authenticate(self):
         backend = load_backend(strategy=self.strategy, name="facebook", redirect_uri="/")


### PR DESCRIPTION
Add default Strategy confirmation and nonce handling for externally resumed partial pipelines.

Bundle a Django template for the confirmation form and include it in distributions.

BREAKING CHANGE: Requires social-auth-core >=5.0.0,<6.0.0 for the external resume Strategy hooks.

Complements https://github.com/python-social-auth/social-core/pull/1816

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
