### PR TITLE
fix(strategy): create sessions before authentication

### DIFF
--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -242,6 +242,8 @@ class DjangoStrategy(BaseStrategy):
         return get_language()
 
     def get_session_id(self) -> str | None:
+        if self.session.session_key is None:
+            self.session.create()
         return self.session.session_key
 
     def restore_session(self, session_id: str, kwargs: dict[str, Any]) -> None:

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -45,6 +45,35 @@ class TestStrategy(TestCase):
         self.assertEqual(self.strategy.session_setdefault("k", "x"), "v")
         self.assertEqual(self.strategy.session_pop("k"), "v")
 
+    def test_get_session_id_creates_session(self):
+        self.assertIsNone(self.strategy.session.session_key)
+
+        session_id = self.strategy.get_session_id()
+
+        self.assertIsNotNone(session_id)
+        self.assertTrue(self.strategy.session.exists(session_id))
+
+    def test_get_session_id_reuses_existing_session(self):
+        self.strategy.session.create()
+        session_id = self.strategy.session.session_key
+
+        self.assertEqual(self.strategy.get_session_id(), session_id)
+
+    def test_new_session_can_be_restored_without_cookie(self):
+        session_id = self.strategy.get_session_id()
+        if session_id is None:
+            self.fail("session ID was not created")
+        self.strategy.session_set("saml_authn_request_id", "TEST_ID")
+        self.strategy.session.save()
+
+        callback_request = self.request_factory.post("/")
+        SessionMiddleware(lambda _request: HttpResponse()).process_request(callback_request)
+        callback_strategy = load_strategy(request=callback_request)
+        callback_strategy.restore_session(session_id, {})
+
+        self.assertEqual(callback_strategy.session_get("saml_authn_request_id"), "TEST_ID")
+        self.assertNotEqual(callback_strategy.get_session_id(), session_id)
+
     def test_random_string(self):
         rs1 = self.strategy.random_string()
         self.assertEqual(len(rs1), 12)


### PR DESCRIPTION
Cross-site SAML POST callbacks can omit SameSite session cookies. Create fresh server-side sessions before RelayState is built so AuthnRequest IDs can be restored and validated.

Fixes: python-social-auth/social-core#1857

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
