### PR TITLE
fix: preserve Django request during authentication

### DIFF
--- a/social_django/strategy.py
+++ b/social_django/strategy.py
@@ -190,11 +190,12 @@ class DjangoStrategy(BaseStrategy):
         except (TypeError, TemplateDoesNotExist):
             return render_template_string(self.request, html, context)
 
-    def authenticate(self, backend, *args, **kwargs):
+    def authenticate(self, backend, **kwargs):
         kwargs["strategy"] = self
         kwargs["storage"] = self.storage
         kwargs["backend"] = backend
-        return authenticate(*args, **kwargs)
+        kwargs.pop("request", None)
+        return authenticate(self.request, **kwargs)
 
     def clean_authenticate_args(self, request, *args, **kwargs):
         # pipelines don't want a positional request argument

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -273,6 +273,18 @@ class TestStrategy(TestCase):
             self.assertEqual(result, user)
             self.assertEqual(result.backend, "social_core.backends.facebook.FacebookOAuth2")
 
+    def test_authenticate_uses_strategy_request(self):
+        backend = load_backend(strategy=self.strategy, name="facebook", redirect_uri="/")
+        user = mock.Mock()
+        with mock.patch("social_core.backends.base.BaseAuth.pipeline", return_value=user) as pipeline:
+            self.strategy.authenticate(
+                backend=backend,
+                response=mock.Mock(),
+                request=QueryDict("partial_token=token"),
+            )
+
+        self.assertIs(pipeline.call_args.kwargs["request"], self.request)
+
     def test_clean_authenticate_args(self):
         args, kwargs = self.strategy.clean_authenticate_args(self.request)
         self.assertEqual(args, ())


### PR DESCRIPTION
Always pass the strategy's HttpRequest to Django authentication so partial pipeline data cannot replace it.

Fixes #1064

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
