### PR TITLE
fix(admin): replace deprecated list_select_related = True

### DIFF
--- a/social_django/admin.py
+++ b/social_django/admin.py
@@ -17,7 +17,7 @@ class UserSocialAuthOption(admin.ModelAdmin):
     list_filter = ("provider",)
     raw_id_fields = ("user",)
     readonly_fields = ("created", "modified")
-    list_select_related = True
+    list_select_related = ("user",)
 
     def get_search_fields(self, request=None):
         search_fields = getattr(settings, setting_name("ADMIN_USER_SEARCH_FIELDS"), None)


### PR DESCRIPTION
Django 6.0 deprecates the bare `True` sentinel for
`Admin.list_select_related` and emits a `RemovedInDjango70Warning`;
Django 7.0 will reject the value outright.

There is no migration benefit lost here: `True` only ever wrapped the
`user` foreign key in practice, so selecting it explicitly preserves
the query behaviour while taking the deprecation away for projects
whose admin autodiscovers this module.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>