### PR TITLE
feat(middleware): add configurable error transport to SocialAuthExceptionMiddleware (#1067)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ pip-log.txt
 .coverage
 .coverage.*
 .tox
+coverage.xml
+htmlcov/
 uv.lock
 
 # Translations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added configurable error transport (`ErrorTransport.MESSAGES`, `ErrorTransport.QUERY`) via `SOCIAL_AUTH_ERROR_TRANSPORT` to `SocialAuthExceptionMiddleware`.
+
 ## [6.0.1](https://github.com/python-social-auth/social-app-django/releases/tag/6.0.1) - 2026-07-24
 
 ### Fixed

--- a/social_django/middleware.py
+++ b/social_django/middleware.py
@@ -1,4 +1,9 @@
-from urllib.parse import quote
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.apps import apps
@@ -9,6 +14,19 @@ from django.shortcuts import redirect
 from django.utils.decorators import sync_and_async_middleware
 from social_core.exceptions import SocialAuthBaseException
 from social_core.utils import social_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from typing import ClassVar
+
+    from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+
+
+class ErrorTransport(str, Enum):
+    """Transport mechanisms for delivering social auth error messages to the client."""
+
+    MESSAGES = "messages"
+    QUERY = "query"
 
 
 @sync_and_async_middleware
@@ -21,57 +39,194 @@ class SocialAuthExceptionMiddleware:
     redirected to the location specified in the SOCIAL_AUTH_LOGIN_ERROR_URL
     setting.
 
+    Error transport can be configured via the SOCIAL_AUTH_ERROR_TRANSPORT setting
+    as a list of ErrorTransport enum values or strings:
+    - ErrorTransport.MESSAGES ('messages', default): Uses django.contrib.messages framework.
+    - ErrorTransport.QUERY ('query'): Encodes error message and backend into the redirect URL query parameters.
+
     This middleware can be extended by overriding the get_message or
     get_redirect_uri methods, which each accept request and exception.
     """
 
-    def __init__(self, get_response):
+    DEFAULT_TRANSPORT: ClassVar[list[ErrorTransport]] = [ErrorTransport.MESSAGES]
+    ERROR_PARAM_NAME: ClassVar[str] = "message"
+    BACKEND_PARAM_NAME: ClassVar[str] = "backend"
+
+    get_response: Callable[[HttpRequest], HttpResponse | Awaitable[HttpResponse]]
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse | Awaitable[HttpResponse]],
+    ) -> None:
+        """Initialize the middleware with the next response handler.
+
+        Marks the middleware as coroutine function if get_response is async.
+        """
         self.get_response = get_response
 
         if iscoroutinefunction(get_response):
             markcoroutinefunction(self)
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest) -> HttpResponse | Awaitable[HttpResponse]:
+        """Process the incoming request and return the response."""
         return self.get_response(request)
 
-    def process_exception(self, request, exception):
+    def process_exception(self, request: HttpRequest, exception: Exception) -> HttpResponseRedirect | None:
+        """Process caught SocialAuthBaseException instances.
+
+        Dispatches error messages across configured transports (messages, query parameters)
+        and redirects to the error URL.
+        """
         strategy = getattr(request, "social_strategy", None)
+        # Guard 1: Skip if no strategy is available or if the exception should be re-raised
         if strategy is None or self.raise_exception(request, exception):
             return None
 
-        if isinstance(exception, SocialAuthBaseException):
-            backend = getattr(request, "backend", None)
-            backend_name = getattr(backend, "name", "unknown-backend")
+        # Guard 2: Skip if the exception is not a SocialAuthBaseException
+        if not isinstance(exception, SocialAuthBaseException):
+            return None
 
-            message = self.get_message(request, exception)
-            url = self.get_redirect_uri(request, exception)
+        backend = getattr(request, "backend", None)
+        backend_name = getattr(backend, "name", "unknown-backend")
 
+        message = self.get_message(request, exception)
+        url = self.get_redirect_uri(request, exception)
+        transports = self.get_transport_modes(request)
+
+        url = self.dispatch_error(request, transports, url, message, backend_name)
+
+        if url:
+            return redirect(url)
+        return None
+
+    def dispatch_error(
+        self,
+        request: HttpRequest,
+        transports: list[ErrorTransport],
+        url: str | None,
+        message: str,
+        backend_name: str,
+    ) -> str | None:
+        """Dispatch the error across the configured error transport mechanisms.
+
+        Handles Django messages and URL query parameter appending, returning
+        the potentially updated redirect URL.
+        """
+        # 1. Handle Django Messages transport if enabled
+        if ErrorTransport.MESSAGES in transports:
             if apps.is_installed("django.contrib.messages"):
                 social_logger.info(message)
                 try:
                     messages.error(request, message, extra_tags=f"social-auth {backend_name}")
                 except MessageFailure:
-                    if url:
-                        url += (("?" in url and "&") or "?") + f"message={quote(message)}&backend={backend_name}"
-            else:
+                    # Fallback to query parameter if message backend storage fails
+                    if ErrorTransport.QUERY not in transports:
+                        url = self.append_query_params(request, url, message, backend_name)
+            elif ErrorTransport.QUERY not in transports:
                 social_logger.error(message)
 
-            if url:
-                return redirect(url)
-            return None
-        return None
+        # 2. Handle Query Parameter transport if enabled
+        if ErrorTransport.QUERY in transports:
+            if ErrorTransport.MESSAGES not in transports or not apps.is_installed("django.contrib.messages"):
+                social_logger.info(message)
+            url = self.append_query_params(request, url, message, backend_name)
 
-    def raise_exception(self, request, exception):
+        return url
+
+    def get_transport_modes(self, request: HttpRequest) -> list[ErrorTransport]:
+        """Resolve and return the configured list of ErrorTransport modes for the request/backend.
+
+        Checks the ERROR_TRANSPORT setting (backend-specific if available),
+        normalizing single items and iterables. Falls back to DEFAULT_TRANSPORT
+        if no valid modes are found.
+        """
+        strategy = getattr(request, "social_strategy", None)
+        backend = getattr(request, "backend", None)
+        if strategy is None:
+            return list(self.DEFAULT_TRANSPORT)
+
+        raw_transports = strategy.setting("ERROR_TRANSPORT", self.DEFAULT_TRANSPORT, backend=backend)
+        if isinstance(raw_transports, (str, ErrorTransport)):
+            candidates = [raw_transports]
+        elif isinstance(raw_transports, Iterable):
+            candidates = list(raw_transports)
+        else:
+            candidates = [raw_transports]
+
+        transports: list[ErrorTransport] = []
+        for item in candidates:
+            if isinstance(item, ErrorTransport):
+                mode = item
+            else:
+                try:
+                    mode = ErrorTransport(str(item).lower().strip())
+                except ValueError:
+                    continue
+            if mode not in transports:
+                transports.append(mode)
+
+        return transports or list(self.DEFAULT_TRANSPORT)
+
+    def get_error_param_name(self, request: HttpRequest) -> str:
+        """Return the query parameter name used for error messages."""
+        strategy = getattr(request, "social_strategy", None)
+        backend = getattr(request, "backend", None)
+        if strategy is not None:
+            return strategy.setting("ERROR_PARAM_NAME", self.ERROR_PARAM_NAME, backend=backend)
+        return self.ERROR_PARAM_NAME
+
+    def get_backend_param_name(self, request: HttpRequest) -> str:
+        """Return the query parameter name used for the backend identifier."""
+        strategy = getattr(request, "social_strategy", None)
+        backend = getattr(request, "backend", None)
+        if strategy is not None:
+            return strategy.setting("BACKEND_PARAM_NAME", self.BACKEND_PARAM_NAME, backend=backend)
+        return self.BACKEND_PARAM_NAME
+
+    def append_query_params(
+        self,
+        request: HttpRequest,
+        url: str | None,
+        message: str,
+        backend_name: str,
+    ) -> str | None:
+        """Append or update error message and backend query parameters in the redirect URL.
+
+        Preserves any existing URL fragments and other parameters while updating
+        configured error parameter names.
+        """
+        if not url:
+            return url
+
+        error_param = self.get_error_param_name(request)
+        backend_param = self.get_backend_param_name(request)
+
+        scheme, netloc, path, query, fragment = urlsplit(url)
+        query_params = parse_qsl(query, keep_blank_values=True)
+
+        # Overwrite existing parameters so the latest failure details from the
+        # current request are passed to the redirect target rather than stale values.
+        updated_params = [(k, v) for k, v in query_params if k not in (error_param, backend_param)]
+        updated_params.append((error_param, message))
+        updated_params.append((backend_param, backend_name))
+
+        new_query = urlencode(updated_params, quote_via=quote)
+        return urlunsplit((scheme, netloc, path, new_query, fragment))
+
+    def raise_exception(self, request: HttpRequest, exception: Exception) -> bool | None:
+        """Return True if the caught exception should be re-raised instead of caught."""
         strategy = getattr(request, "social_strategy", None)
         if strategy is not None:
             backend = getattr(request, "backend", None)
             return strategy.setting("RAISE_EXCEPTIONS", settings.DEBUG, backend=backend)
         return None
 
-    def get_message(self, request, exception):
+    def get_message(self, request: HttpRequest, exception: Exception) -> str:
+        """Return the error message string from the caught exception."""
         return str(exception)
 
-    def get_redirect_uri(self, request, exception):
+    def get_redirect_uri(self, request: HttpRequest, exception: Exception) -> str | None:
+        """Return the redirect URL target for the exception."""
         strategy = getattr(request, "social_strategy", None)
         backend = getattr(request, "backend", None)
         if strategy is None:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -257,3 +257,96 @@ class TestMiddleware(TestCase):
         self.assertTrue(isinstance(response, HttpResponseRedirect))
         self.assertEqual(response.url, "/login")
         mocked_error.assert_called_once()
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.MESSAGES, ErrorTransport.QUERY],
+    )
+    @mock.patch("django.contrib.messages.error", side_effect=MessageFailure)
+    def test_message_failure_when_query_already_in_transports(self, mocked_error, mocked):
+        """Test MessageFailure fallback when QUERY is already enabled in transports."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?message=Authentication%20process%20canceled&backend=facebook",
+        )
+
+    @mock.patch("django.apps.apps.is_installed", return_value=False)
+    @mock.patch("social_django.middleware.social_logger.error")
+    def test_dispatch_error_messages_without_messages_installed(self, mock_logger, mock_is_installed, mocked):
+        """Test dispatch_error logs error when messages app is not installed and query is disabled."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        url = middleware.dispatch_error(
+            request,
+            transports=[ErrorTransport.MESSAGES],
+            url="/login",
+            message="Failed auth",
+            backend_name="facebook",
+        )
+        self.assertEqual(url, "/login")
+        mock_logger.assert_called_once_with("Failed auth")
+
+    @mock.patch("django.apps.apps.is_installed", return_value=False)
+    def test_dispatch_error_messages_not_installed_with_query_enabled(self, mock_is_installed, mocked):
+        """Test dispatch_error when messages app is not installed but query transport is enabled."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        url = middleware.dispatch_error(
+            request,
+            transports=[ErrorTransport.MESSAGES, ErrorTransport.QUERY],
+            url="/login",
+            message="Failed auth",
+            backend_name="facebook",
+        )
+        self.assertEqual(
+            url,
+            "/login?message=Failed%20auth&backend=facebook",
+        )
+
+    def test_get_transport_modes_no_strategy(self, mocked):
+        """Test get_transport_modes returns DEFAULT_TRANSPORT when social_strategy is None."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        modes = middleware.get_transport_modes(request)
+        self.assertEqual(modes, list(middleware.DEFAULT_TRANSPORT))
+
+    def test_get_transport_modes_non_iterable_raw_transport(self, mocked):
+        """Test get_transport_modes handles non-iterable, non-string configuration gracefully."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        mock_strategy = mock.Mock()
+        mock_strategy.setting.return_value = 12345
+        request.social_strategy = mock_strategy
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        modes = middleware.get_transport_modes(request)
+        self.assertEqual(modes, list(middleware.DEFAULT_TRANSPORT))
+
+    def test_get_transport_modes_deduplication(self, mocked):
+        """Test get_transport_modes deduplicates candidate transports."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        mock_strategy = mock.Mock()
+        mock_strategy.setting.return_value = ["query", "query", ErrorTransport.MESSAGES, "messages"]
+        request.social_strategy = mock_strategy
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        modes = middleware.get_transport_modes(request)
+        self.assertEqual(modes, [ErrorTransport.QUERY, ErrorTransport.MESSAGES])
+
+    def test_raise_exception_without_strategy(self, mocked):
+        """Test raise_exception returns None when social_strategy is None."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        self.assertIsNone(middleware.raise_exception(request, Exception("error")))
+
+    def test_get_redirect_uri_without_strategy(self, mocked):
+        """Test get_redirect_uri returns None when social_strategy is None."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        self.assertIsNone(middleware.get_redirect_uri(request, Exception("error")))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -8,7 +8,7 @@ from django.test import AsyncRequestFactory, RequestFactory, TestCase, override_
 from django.urls import reverse
 from social_core.exceptions import AuthCanceled
 
-from social_django.middleware import SocialAuthExceptionMiddleware
+from social_django.middleware import ErrorTransport, SocialAuthExceptionMiddleware
 
 
 class MockAuthCanceled(AuthCanceled):
@@ -100,3 +100,160 @@ class TestMiddleware(TestCase):
         with self.assertRaises(MockAuthCanceled):
             self.client.get(self.complete_url)
         logging.disable(logging.NOTSET)
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.QUERY],
+    )
+    @mock.patch("django.contrib.messages.error")
+    def test_error_transport_query(self, mocked_error, mocked):
+        """Test query parameter transport redirects with query parameters and skips messages."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?message=Authentication%20process%20canceled&backend=facebook",
+        )
+        mocked_error.assert_not_called()
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT="query",
+    )
+    def test_error_transport_query_as_string(self, mocked):
+        """Test query parameter transport configured as a string value."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?message=Authentication%20process%20canceled&backend=facebook",
+        )
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.MESSAGES],
+        SOCIAL_AUTH_FACEBOOK_ERROR_TRANSPORT=[ErrorTransport.QUERY],
+    )
+    def test_backend_specific_error_transport(self, mocked):
+        """Test backend-specific ERROR_TRANSPORT override."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?message=Authentication%20process%20canceled&backend=facebook",
+        )
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.MESSAGES, ErrorTransport.QUERY],
+    )
+    @mock.patch("django.contrib.messages.error")
+    def test_error_transport_multiple(self, mocked_error, mocked):
+        """Test configuring multiple transports (both messages and query)."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?message=Authentication%20process%20canceled&backend=facebook",
+        )
+        mocked_error.assert_called_once()
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.QUERY],
+        SOCIAL_AUTH_ERROR_PARAM_NAME="err",
+        SOCIAL_AUTH_BACKEND_PARAM_NAME="auth_backend",
+    )
+    def test_custom_param_names_via_settings(self, mocked):
+        """Test configuring custom query parameter names via Django settings."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?err=Authentication%20process%20canceled&auth_backend=facebook",
+        )
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=[ErrorTransport.QUERY],
+        SOCIAL_AUTH_FACEBOOK_ERROR_PARAM_NAME="fb_err",
+        SOCIAL_AUTH_FACEBOOK_BACKEND_PARAM_NAME="fb_backend",
+    )
+    def test_backend_specific_custom_param_names(self, mocked):
+        """Test backend-specific custom query parameter names."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/login?fb_err=Authentication%20process%20canceled&fb_backend=facebook",
+        )
+
+    def test_custom_param_names_via_subclass(self, mocked):
+        """Test custom parameter names configured via subclass attributes."""
+
+        class CustomMiddleware(SocialAuthExceptionMiddleware):
+            ERROR_PARAM_NAME = "custom_err"
+            BACKEND_PARAM_NAME = "custom_be"
+
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = CustomMiddleware(mock.Mock())
+        result_url = middleware.append_query_params(request, "/login", "failed", "google")
+        self.assertEqual(result_url, "/login?custom_err=failed&custom_be=google")
+
+    def test_append_query_params_preserves_existing_params_and_overwrites(self, mocked):
+        """Test append_query_params preserves other params and overwrites duplicate error params."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+
+        # Preserves existing parameters
+        url = middleware.append_query_params(request, "/login?next=/dashboard&mode=dark", "Error msg", "twitter")
+        self.assertEqual(
+            url,
+            "/login?next=%2Fdashboard&mode=dark&message=Error%20msg&backend=twitter",
+        )
+
+        # Overwrites existing message and backend parameters
+        overwrite_url = middleware.append_query_params(
+            request,
+            "/login?message=old_error&backend=old_backend&keep=1",
+            "New error",
+            "github",
+        )
+        self.assertEqual(
+            overwrite_url,
+            "/login?keep=1&message=New%20error&backend=github",
+        )
+
+    def test_append_query_params_preserves_url_fragment(self, mocked):
+        """Test append_query_params places query parameters before URL fragment."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+
+        url = middleware.append_query_params(request, "/login/#/auth-callback", "Canceled", "facebook")
+        self.assertEqual(
+            url,
+            "/login/?message=Canceled&backend=facebook#/auth-callback",
+        )
+
+    def test_append_query_params_empty_url(self, mocked):
+        """Test append_query_params handles empty or None URL gracefully."""
+        rf = RequestFactory()
+        request = rf.get("/")
+        middleware = SocialAuthExceptionMiddleware(mock.Mock())
+        self.assertIsNone(middleware.append_query_params(request, None, "msg", "be"))
+        self.assertEqual(middleware.append_query_params(request, "", "msg", "be"), "")
+
+    @override_settings(
+        SOCIAL_AUTH_LOGIN_ERROR_URL="/login",
+        SOCIAL_AUTH_ERROR_TRANSPORT=["invalid_transport"],
+    )
+    @mock.patch("django.contrib.messages.error")
+    def test_invalid_error_transport_fallback(self, mocked_error, mocked):
+        """Test unrecognized transport falls back to DEFAULT_TRANSPORT (messages)."""
+        response = self.client.get(self.complete_url)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(response.url, "/login")
+        mocked_error.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a configurable error transport mechanism to `SocialAuthExceptionMiddleware` to support Single Page Applications (SPAs) and hybrid setups that cannot rely solely on `django.contrib.messages`.

Closes #1067

## Changes

- **`ErrorTransport` Enum**: Added `ErrorTransport` with `MESSAGES = "messages"` and `QUERY = "query"`.
- **Configurable Setting**: Supported `SOCIAL_AUTH_ERROR_TRANSPORT` (and backend-specific overrides) accepting a list of transports or single string/enum, defaulting to `[ErrorTransport.MESSAGES]` for full backwards compatibility.
- **Configurable Parameter Names**: Added `SOCIAL_AUTH_ERROR_PARAM_NAME` (default: `"message"`) and `SOCIAL_AUTH_BACKEND_PARAM_NAME` (default: `"backend"`), configurable via settings or middleware subclass attributes.
- **Robust URL Handling**: Uses `urllib.parse` (`urlsplit`, `parse_qsl`, `urlencode`, `urlunsplit`) to preserve URL fragments (`#...`) and cleanly overwrite stale error parameters.
- **Typing & Docs**: Added `from __future__ import annotations`, complete type hints, and docstrings.
- **Documentation**: Updated `CHANGELOG.md` with an `## Unreleased` section.

## Verification

- `uv run pre-commit run --all-files`: All hooks passed.
- `uv run mypy social_django/middleware.py`: 0 errors.
- `uv run pyright social_django/middleware.py`: 0 errors.
- `uv run python manage.py test`: 101 tests passed.